### PR TITLE
Hotfix 5.0.4

### DIFF
--- a/src/NServiceBus.Distributor.MSMQ/MsmqWorkerAvailabilityManager.cs
+++ b/src/NServiceBus.Distributor.MSMQ/MsmqWorkerAvailabilityManager.cs
@@ -127,19 +127,10 @@ namespace NServiceBus.Distributor.MSMQ
         {
             string sessionId;
 
-            if (!registeredWorkerAddresses.TryGetValue(worker.Address, out sessionId))
-            {
-                // The worker send us a message before the "WorkerStarting" message
-                Logger.InfoFormat("Dropping ready message from Worker at '{0}', because this worker worker sent us a message before the 'WorkerStarting' message.", worker.Address);
-
-                return;
-            }
-
-            if (sessionId.Equals("disconnected"))
+            if (registeredWorkerAddresses.TryGetValue(worker.Address, out sessionId) && sessionId.Equals("disconnected"))
             {
                 // Drop ready message as this worker has been disconnected 
                 Logger.InfoFormat("Dropping ready message from Worker at '{0}', because this worker has been disconnected.", worker.Address);
-
                 return;
             }
 

--- a/src/NServiceBus.Distributor.MSMQ/MsmqWorkerAvailabilityManager.cs
+++ b/src/NServiceBus.Distributor.MSMQ/MsmqWorkerAvailabilityManager.cs
@@ -116,9 +116,9 @@ namespace NServiceBus.Distributor.MSMQ
 
                 return new Worker(address, sessionId);
             }
-            catch (MessageQueueException e)
+            catch (MessageQueueException e) when (e.MessageQueueErrorCode == MessageQueueErrorCode.IOTimeout)
             {
-                Logger.InfoFormat("NextAvailableWorker Exception", e);
+                Logger.Debug("NextAvailableWorker IOTimeout");
                 return null;
             }
         }

--- a/src/NServiceBus.Distributor.MSMQ/NServiceBus.Distributor.MSMQ.csproj
+++ b/src/NServiceBus.Distributor.MSMQ/NServiceBus.Distributor.MSMQ.csproj
@@ -15,7 +15,8 @@
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>486aa6c5</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,9 +46,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Janitor, Version=1.1.0.0, Culture=neutral, PublicKeyToken=d34c7d3bba3746e6, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Janitor.Fody.1.1.0.0\Lib\portable-net4+sl5+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\Janitor.dll</HintPath>
+    <Reference Include="Janitor, Version=1.1.4.0, Culture=neutral, PublicKeyToken=d34c7d3bba3746e6, processorArchitecture=MSIL">
+      <HintPath>..\packages\Janitor.Fody.1.1.4.0\Lib\dotnet\Janitor.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -55,9 +55,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NServiceBus.5.0.2\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Obsolete, Version=3.1.0.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Obsolete.Fody.3.1.0.0\Lib\NET35\Obsolete.dll</HintPath>
+    <Reference Include="Obsolete, Version=4.0.3.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obsolete.Fody.4.0.3\Lib\dotnet\Obsolete.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -92,15 +91,19 @@
     <Content Include="FodyWeavers.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.1.25.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.25.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.25.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.25.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets'))" />
     <Error Condition="!Exists('..\packages\NuGetPackager.0.4.13\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.4.13\build\NuGetPackager.targets'))" />
+    <Error Condition="!Exists('..\packages\Janitor.Fody.1.1.4.0\build\dotnet\Janitor.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Janitor.Fody.1.1.4.0\build\dotnet\Janitor.Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Obsolete.Fody.4.0.3\build\dotnet\Obsolete.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Obsolete.Fody.4.0.3\build\dotnet\Obsolete.Fody.targets'))" />
   </Target>
   <Import Project="..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets')" />
   <Import Project="..\packages\NuGetPackager.0.4.13\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.4.13\build\NuGetPackager.targets')" />
+  <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
+  <Import Project="..\packages\Janitor.Fody.1.1.4.0\build\dotnet\Janitor.Fody.targets" Condition="Exists('..\packages\Janitor.Fody.1.1.4.0\build\dotnet\Janitor.Fody.targets')" />
+  <Import Project="..\packages\Obsolete.Fody.4.0.3\build\dotnet\Obsolete.Fody.targets" Condition="Exists('..\packages\Obsolete.Fody.4.0.3\build\dotnet\Obsolete.Fody.targets')" />
 </Project>

--- a/src/NServiceBus.Distributor.MSMQ/packages.config
+++ b/src/NServiceBus.Distributor.MSMQ/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fody" version="1.25.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Fody" version="1.29.4" targetFramework="net45" developmentDependency="true" />
   <package id="GitVersionTask" version="2.0.1" targetFramework="net45" developmentDependency="true" />
-  <package id="Janitor.Fody" version="1.1.0.0" targetFramework="net45" />
+  <package id="Janitor.Fody" version="1.1.4.0" targetFramework="net45" developmentDependency="true" />
   <package id="NServiceBus" version="5.0.2" targetFramework="net45" />
   <package id="NuGetPackager" version="0.4.13" targetFramework="net45" />
-  <package id="Obsolete.Fody" version="3.1.0.0" targetFramework="net45" />
+  <package id="Obsolete.Fody" version="4.0.3" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This fixes #34

## Behavior

### Distributor restart when worker is under load

Assuming worker(s) are setup correctly.

- After a restart the distributor receives RDY message and registers this in the storage queue with the session ID from the RDY message.
- Incoming business message will be forwarded to worker with session ID from storage message.
- Worker processes message
- Worker sends RDY message to distributor if it has matching session ID

### Worker crashes when under full load

- Worker queue has # message equal to concurrency limit
- Worker sends WorkerCapacityAvailable with concurrency limit + session ID
- Distributor writes RDY message to storage queues based on this limit
- Distributor sends new messages to worker as it thinks it is not processing any messages
- Worker has now also a backlog of messages equal to the concurrency limit
- After worker finished processing messages from its backlog it only send RDY messages with a matching session ID back to the distributor.

## Drawback

If the workers continiously crashes, its queue will be filled with message as it is deemed available by the distributor.

The only way to solve this is:

- When distributor receives WorkerCapacityAvailable, it sends an ACK+SessionID to the worker
- When worker receives an ACK it sends RDY messages if the SessionID matches

This works, as the backlog of existing messages will now have been processed. I do assume here that messages are processed chronologycally.

We could even filter 'old' items from the storage queue before sending the ACK. This makes sure that no new work will be send to the worker until it send all its RDY messages based on the ACK.
