### PR TITLE
When a master with worker defines a master node config, then ignore it.

### DIFF
--- a/src/NServiceBus.Distributor.MSMQ/MasterNodeConfiguration.cs
+++ b/src/NServiceBus.Distributor.MSMQ/MasterNodeConfiguration.cs
@@ -9,8 +9,12 @@ namespace NServiceBus
     {
         public static string GetMasterNode(ReadOnlySettings settings)
         {
+            if (settings.GetOrDefault<bool>("Distributor.WithWorker"))
+            {
+                return null;
+            }
             var section = settings.GetConfigSection<MasterNodeConfig>();
-            return section != null ? section.Node : null;
+            return section?.Node;
         }
 
         public static Address GetMasterNodeAddress(ReadOnlySettings settings)


### PR DESCRIPTION
Fixes #42 

@DavidBoike have a look